### PR TITLE
 Output error stack only once 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 
 node_js:
-  - 0.8
+  - 6.0
+  - 8.0

--- a/log.js
+++ b/log.js
@@ -1,43 +1,37 @@
 // Copyright 2011-2012 mbr targeting GmbH. All Rights Reserved.
 
-var util = require('util');
+const util = require('util');
 
-var getenv = require('getenv');
+const getenv = require('getenv');
 
-var logLevels = ['fatal', 'error', 'warn', 'info', 'debug'];
+const logLevels = ['fatal', 'error', 'warn', 'info', 'debug'];
 
 function findErrors(args) {
-  return args.filter(function(arg) {
-    return arg instanceof Error;
-  });
+  return args.filter((arg) => arg instanceof Error);
 }
 
-var logStack = getenv.bool('LOG_STACK', true);
+const logStack = getenv.bool('LOG_STACK', true);
 function formatErrors(errors) {
   if (!logStack) {
     return '';
   }
 
-  var output = [''];
-  errors.forEach(function(error) {
+  const output = [''];
+  errors.forEach((error) => {
     output.push(error.stack);
 
-    var object = util.inspect(error, true, 3);
+    const object = util.inspect(error, true, 3);
     output.push(object);
   });
   return output.join('\n');
 }
 
 function forward(target, prefix) {
-  return function(format) {
-    format = prefix + format;
-
-    var args = Array.prototype.slice.call(arguments);
-
-    var errors = findErrors(args);
+  return (format, ...args) => {
+    const errors = findErrors(args);
 
     console[target]('%s%s',
-                    util.format.apply(null, args),
+                    util.format(prefix + format, ...args),
                     formatErrors(errors));
   };
 }
@@ -48,8 +42,8 @@ exports.warn = forward('warn', 'WARN : ');
 exports.info = forward('log', 'INFO : ');
 exports.debug = forward('log', 'DEBUG: ');
 
-var logLevel = getenv.string('LOG_LEVEL', 'debug');
-var index = logLevels.indexOf(logLevel);
+const logLevel = getenv.string('LOG_LEVEL', 'debug');
+const index = logLevels.indexOf(logLevel);
 if (index === -1) {
   throw new Error('Log.InvalidLogLevel: ' + logLevel + ', set LOG_LEVEL');
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "node": "*"
   },
   "dependencies": {
-    "getenv": "^0.7.0"
+    "getenv": "^0.7.0",
+    "lodash.iserror": "^3.1.1",
+    "lodash.isstring": "^4.0.1"
   },
   "devDependencies": {
     "sinon": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "node": "*"
   },
   "dependencies": {
-    "getenv": "0.3.0"
+    "getenv": "^0.7.0"
   },
   "devDependencies": {
-    "sinon": "~1.3.4"
+    "sinon": "^3.0.0"
   }
 }

--- a/test/log.js
+++ b/test/log.js
@@ -52,8 +52,20 @@ tests['log.XXX() with error stacks'] = function testErrorStacks() {
   assert.ok(message.indexOf('testErrorStacks') !== -1);
   assert.ok(message.indexOf('Error one') !== -1);
   assert.ok(message.indexOf('Error two') !== -1);
+  assert.strictEqual(message.match(/\btestErrorStacks\b/g).length, 2);
 
-  console.error.reset();
+  console.error.restore();
+};
+
+tests['Error should only be rendered once'] = function() {
+  sinon.spy(console, 'error');
+
+  log.error('Message:', new Error('error'));
+  var call = console.error.getCall(0);
+  var message = util.format.apply(null, call.args);
+  assert.strictEqual(message.match(/\bError: error\b/g).length, 1);
+
+  console.error.restore();
 };
 
 Object.keys(tests).forEach(function(key) {


### PR DESCRIPTION
Starting with node 6 `util.inspect()` (and therefore `console.log()`)
render the full error stack. This causes errors without placeholder
passed to `log` being output three times. Fix this by passing only
arguments with placeholders to `util.format()` and only rendering the
output of `util.inspect()` for error stacks.